### PR TITLE
Multiple inputs & nearest neighbors

### DIFF
--- a/mapillm/agent.py
+++ b/mapillm/agent.py
@@ -8,8 +8,6 @@ import os
 
 # reaction = SynthesisReactions()
 
-print("apsidjaiposdhu")
-
 class Agent:
     def __init__(self, openai_api_key, mapi_api_key): 
         self.llm = ChatOpenAI(

--- a/mapillm/exact_match_demo.ipynb
+++ b/mapillm/exact_match_demo.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/samcox/anaconda3/envs/mapi/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from mp_api.client import MPRester\n",
+    "os.environ[\"MAPI_API_KEY\"] = \"MY_API_KEY\"\n",
+    "mpr = MPRester(os.getenv(\"MAPI_API_KEY\")) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from exact_matching import ExactMatchingTool\n",
+    "exact_matching = ExactMatchingTool()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Case 1: We know the formula, density, and the symmetry info (lattice & space group)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formula=\"LiCoO2\"\n",
+    "space_group = 12\n",
+    "lattice=\"Monoclinic\"\n",
+    "density=4.7\n",
+    "prop=\"band_gap\"\n",
+    "\n",
+    "input_dict_full = {\"formula\": formula, \"space_group_num\": space_group, \"lattice\": lattice, \"density\": density, \"desired_prop\": prop}\n",
+    "results = exact_matching.query_material_property(**input_dict_full, one_only=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\u001b[4m\u001b[1mMPDataDoc<SummaryDoc>\u001b[0;0m\u001b[0;0m(\n",
+       " \u001b[1mformula_pretty\u001b[0;0m='LiCoO2',\n",
+       " \u001b[1mdensity\u001b[0;0m=4.6776427564172245,\n",
+       " \u001b[1msymmetry\u001b[0;0m=SymmetryData(crystal_system=<CrystalSystem.mono: 'Monoclinic'>, symbol='C2/m', number=12, point_group='2/m', symprec=0.1, version='2.0.2'),\n",
+       " \u001b[1mband_gap\u001b[0;0m=2.0128000000000004,\n",
+       " \u001b[1mfields_not_requested\u001b[0;0m=['builder_meta', 'nsites', 'elements', 'nelements', 'composition', 'composition_reduced', 'formula_anonymous', 'chemsys', 'volume', 'density_atomic', 'property_name', 'material_id', 'deprecated', 'deprecation_reasons', 'last_updated', 'origins', 'warnings', 'structure', 'task_ids', 'uncorrected_energy_per_atom', 'energy_per_atom', 'formation_energy_per_atom', 'energy_above_hull', 'is_stable', 'equilibrium_reaction_energy_per_atom', 'decomposes_to', 'xas', 'grain_boundaries', 'cbm', 'vbm', 'efermi', 'is_gap_direct', 'is_metal', 'es_source_calc_id', 'bandstructure', 'dos', 'dos_energy_up', 'dos_energy_down', 'is_magnetic', 'ordering', 'total_magnetization', 'total_magnetization_normalized_vol', 'total_magnetization_normalized_formula_units', 'num_magnetic_sites', 'num_unique_magnetic_sites', 'types_of_magnetic_species', 'bulk_modulus', 'shear_modulus', 'universal_anisotropy', 'homogeneous_poisson', 'e_total', 'e_ionic', 'e_electronic', 'n', 'e_ij_max', 'weighted_surface_energy_EV_PER_ANG2', 'weighted_surface_energy', 'weighted_work_function', 'surface_anisotropy', 'shape_factor', 'has_reconstructed', 'possible_species', 'has_props', 'theoretical', 'database_IDs']\n",
+       " )]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Property band_gap: [2.0128000000000004]\n"
+     ]
+    }
+   ],
+   "source": [
+    "#just the property\n",
+    "print (f\"Property {prop}: {exact_matching._get_prop(results, prop)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Case 2: We know less information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formula=\"LiCoO2\"\n",
+    "#space_group = 12\n",
+    "lattice=\"Monoclinic\"\n",
+    "#density=4.7\n",
+    "prop=\"band_gap\"\n",
+    "\n",
+    "input_dict_missing = {\"formula\": formula, \"desired_prop\": prop}\n",
+    "results = exact_matching.query_material_property(**input_dict_missing, one_only=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Property band_gap: 0.8278000000000001\n"
+     ]
+    }
+   ],
+   "source": [
+    "#hm...there are 9 resutls. Lets get the average overal all of them\n",
+    "\n",
+    "average_prop = exact_matching.average_vanilla(results, prop)\n",
+    "print (f\"Property {prop}: {average_prop}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Case 3: There are no results for what we want to know about"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "formula = \"LiFePO4\"\n",
+    "space_group = 250\n",
+    "lattice = \"Cubic\"\n",
+    "density = 4.87\n",
+    "prop = \"band_gap\"\n",
+    "\n",
+    "input_dict_no_results = {\"formula\": formula, \"space_group_num\": space_group, \"lattice\": lattice, \"density\": density, \"desired_prop\": prop}\n",
+    "\n",
+    "results = exact_matching.query_material_property(**input_dict_no_results, one_only=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Hm...its blank. Lets try to get the average of all the nearest neighbors\n",
+    "nearest_neighbor_avg = exact_matching.get_weighted_average_of_neighbors(input_dict_no_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Property band_gap: 3.1868915094339627\n"
+     ]
+    }
+   ],
+   "source": [
+    "print (f\"Property {prop}: {nearest_neighbor_avg}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Putting it all together"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: multiple matches found. Returning average of all matches. To get all matches, set one_only=False.\n",
+      "Property band_gap: 2.0128000000000004\n"
+     ]
+    }
+   ],
+   "source": [
+    "#case 1:\n",
+    "formula=\"LiCoO2\"\n",
+    "space_group = 12\n",
+    "lattice=\"Monoclinic\"\n",
+    "density=4.7\n",
+    "prop=\"band_gap\"\n",
+    "\n",
+    "input_dict_full = {\"formula\": formula, \"space_group_num\": space_group, \"lattice\": lattice, \"density\": density, \"desired_prop\": prop}\n",
+    "\n",
+    "results = exact_matching.get_prop(**input_dict_full)\n",
+    "print (f\"Property {prop}: {results}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: multiple matches found. Returning average of all matches. To get all matches, set one_only=False.\n",
+      "Property band_gap: 0.8278000000000001\n"
+     ]
+    }
+   ],
+   "source": [
+    "#case 2:\n",
+    "formula=\"LiCoO2\"\n",
+    "lattice=\"Monoclinic\"\n",
+    "prop=\"band_gap\"\n",
+    "\n",
+    "input_dict_missing = {\"formula\": formula, \"desired_prop\": prop}\n",
+    "\n",
+    "results = exact_matching.get_prop(**input_dict_missing)\n",
+    "print (f\"Property {prop}: {results}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: no matches found. Returning the average of closet matches.\n",
+      "Property band_gap: 3.1868915094339627\n"
+     ]
+    }
+   ],
+   "source": [
+    "#case 3:\n",
+    "formula = \"LiFePO4\"\n",
+    "space_group = 250\n",
+    "lattice = \"Cubic\"\n",
+    "density = 4.87\n",
+    "prop = \"band_gap\"\n",
+    "\n",
+    "input_dict_no_results = {\"formula\": formula, \"space_group_num\": space_group, \"lattice\": lattice, \"density\": density, \"desired_prop\": prop}\n",
+    "\n",
+    "results = exact_matching.get_prop(**input_dict_no_results)\n",
+    "print (f\"Property {prop}: {results}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mapi",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mapillm/exact_matching.py
+++ b/mapillm/exact_matching.py
@@ -1,95 +1,131 @@
 import os
 from mp_api.client import MPRester
+import sys
+
+
+class SuppressOutput:
+    #this is just because I'm annoyed with the print statements and progress bars from mp-api
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+        self._original_stderr = sys.stderr
+        sys.stderr = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout
+        sys.stderr.close()
+        sys.stderr = self._original_stderr
 
 class ExactMatchingTool():
   #move to other class when ready
-  def __init__(self):
-    self.mpr = MPRester(os.getenv("MAPI_API_KEY"))
+    def __init__(self):
+        self.mpr = MPRester(os.getenv("MAPI_API_KEY"))
 
-  def _get_specific_query(self, docs, space_group_num=None, density=None, lattice=None):
-      if space_group_num:
-          docs = [doc for doc in docs if doc.symmetry.number == space_group_num]
-      if density:
-          #instead of exact matching density, get density match to the first decimal
-          docs = [doc for doc in docs if round(doc.density, 1) == round(density, 1)]
-      if lattice:
-          docs = [doc for doc in docs if doc.symmetry.crystal_system.value == lattice]
-      return docs
+    def _get_specific_query(self, docs, space_group_num=None, density=None, lattice=None):
+        if space_group_num:
+            docs = [doc for doc in docs if doc.symmetry.number == space_group_num]
+        if density:
+            #instead of exact matching density, get density match to the first decimal
+            docs = [doc for doc in docs if round(doc.density, 1) == round(density, 1)]
+        if lattice:
+            docs = [doc for doc in docs if doc.symmetry.crystal_system.value == lattice]
+        return docs
   
-  def query_material_property(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
-      docs = self.mpr.materials.summary.search(formula=formula, fields=["formula_pretty", desired_prop, "symmetry", "density", "lattice"])
-      docs = self._get_specific_query(docs, space_group_num, density, lattice)
-      if not docs:
-          return []
-      if one_only:
-          docs = [docs[0]]
-      return docs
+    def query_material_property(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
+        with SuppressOutput(): 
+            docs = self.mpr.materials.summary.search(formula=formula, fields=["formula_pretty", desired_prop, "symmetry", "density", "lattice"])
+        docs = self._get_specific_query(docs, space_group_num, density, lattice)
+        if not docs:
+            return []
+        if one_only:
+            docs = [docs[0]]
+        return docs
   
-  def _get_prop(self, docs, prop):
-      props = []
-      for doc in docs:
-          props.append(getattr(doc, prop))
-      return props
-  
-  def average_neighbors(self, neighbors:dict):
-      total_weight = 0
-      weighted_sum = 0
-      
-      for score, values in neighbors.items():
-          weighted_sum += score * sum(values)
-          total_weight += score * len(values)
-      
-      if total_weight == 0:
-          return 0  
-      else:
-          return weighted_sum / total_weight
-   
-  def k_vals(self, input_param:dict, k:int):
-    num_values = 0
-    for key in input_param:
-        num_values += len(input_param[key])
-    return num_values >= k
-
-  def get_best_matches(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, k=10):
-    """
-    Get the best matches following the scoring rubric.
-    """
-    N_params = {}
-
-    score_criteria = [
-        # Score 3 criteria
-        [
-            {"formula": formula, "lattice": lattice, "space_group_num": space_group_num, "desired_prop": desired_prop},
-            {"formula": formula, "lattice": lattice, "density": density, "desired_prop": desired_prop},
-            {"formula": formula, "space_group_num": space_group_num, "density": density, "desired_prop": desired_prop}
-        ],
-        # Score 2 criteria
-        [
-            {"formula": formula, "lattice": lattice, "desired_prop": desired_prop},
-            {"formula": formula, "space_group_num": space_group_num, "desired_prop": desired_prop},
-            {"formula": formula, "density": density, "desired_prop": desired_prop}
-        ],
-        # Score 1 criteria
-        [{"formula": formula, "desired_prop": desired_prop}]
-    ]
-    
-    for score, criteria in enumerate(score_criteria, start=1):
+    def _get_prop(self, docs, prop):
         props = []
-        for criterion in criteria:
-            criterion["one_only"] = False  # Apply common property
-            docs = self.query_material_property(**criterion)
-            if docs:
-                props += self._get_prop(docs, desired_prop)
-        N_params[score] = props
+        for doc in docs:
+            props.append(getattr(doc, prop))
+        return props
+  
+    def average_neighbors(self, neighbors:dict):
+        total_weight = 0
+        weighted_sum = 0
         
-        if self.k_vals(N_params, k):
-            return N_params
+        for score, values in neighbors.items():
+            weighted_sum += score * sum(values)
+            total_weight += score * len(values)
+        
+        if total_weight == 0:
+            return 0  
+        else:
+            return weighted_sum / total_weight
+      
+    def average_vanilla(self, all_values:list, property:str):
+        all_values = self._get_prop(all_values, property)
+        return sum(all_values) / len(all_values)
+   
+    def k_vals(self, input_param:dict, k:int):
+        num_values = 0
+        for key in input_param:
+            num_values += len(input_param[key])
+        return num_values >= k
 
-    return N_params
+    def get_best_matches(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, k=10):
+        """
+        Get the best matches following the scoring rubric.
+        """
+        N_params = {}
 
-  def get_weighted_average_of_neighbors(self, input_params:dict):
-    required_params = ["formula", "desired_prop"]
-    if not all([param in input_params for param in required_params]):
-        raise ValueError(f"Missing required parameters: {required_params}")
-    neighbors = self.get_best_matches(**input_params)
-    return self.average_neighbors(neighbors)
+        score_criteria = [
+            # Score 3 criteria
+            [
+                {"formula": formula, "lattice": lattice, "space_group_num": space_group_num, "desired_prop": desired_prop},
+                {"formula": formula, "lattice": lattice, "density": density, "desired_prop": desired_prop},
+                {"formula": formula, "space_group_num": space_group_num, "density": density, "desired_prop": desired_prop}
+            ],
+            # Score 2 criteria
+            [
+                {"formula": formula, "lattice": lattice, "desired_prop": desired_prop},
+                {"formula": formula, "space_group_num": space_group_num, "desired_prop": desired_prop},
+                {"formula": formula, "density": density, "desired_prop": desired_prop}
+            ],
+            # Score 1 criteria
+            [{"formula": formula, "desired_prop": desired_prop}]
+        ]
+        
+        for score, criteria in enumerate(score_criteria, start=1):
+            props = []
+            for criterion in criteria:
+                criterion["one_only"] = False  # Apply common property
+                docs = self.query_material_property(**criterion)
+                if docs:
+                    props += self._get_prop(docs, desired_prop)
+            N_params[score] = props
+            
+            if self.k_vals(N_params, k):
+                return N_params
+
+        return N_params
+
+    def get_weighted_average_of_neighbors(self, input_params:dict):
+        required_params = ["formula", "desired_prop"]
+        if not all([param in input_params for param in required_params]):
+            raise ValueError(f"Missing required parameters: {required_params}")
+        neighbors = self.get_best_matches(**input_params)
+        return self.average_neighbors(neighbors)
+    
+    def get_prop(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
+        docs = self.query_material_property(formula, desired_prop, space_group_num, density, lattice, one_only=False)
+        all_props = self._get_prop(docs, desired_prop)
+        if not docs:
+            print ("Warning: no matches found. Returning the average of closet matches.")
+            nearest_neighbor_avg = self.get_weighted_average_of_neighbors({"formula": formula, "desired_prop": desired_prop, "space_group_num": space_group_num, "density": density, "lattice": lattice})
+            return nearest_neighbor_avg
+        if one_only:
+            average_prop = self.average_vanilla(docs, desired_prop)
+            print ("Warning: multiple matches found. Returning average of all matches. To get all matches, set one_only=False.")
+            return average_prop
+        else:
+            return all_props
+        

--- a/mapillm/exact_matching.py
+++ b/mapillm/exact_matching.py
@@ -1,0 +1,95 @@
+import os
+from mp_api.client import MPRester
+
+class ExactMatchingTool():
+  #move to other class when ready
+  def __init__(self):
+    self.mpr = MPRester(os.getenv("MAPI_API_KEY"))
+
+  def _get_specific_query(self, docs, space_group_num=None, density=None, lattice=None):
+      if space_group_num:
+          docs = [doc for doc in docs if doc.symmetry.number == space_group_num]
+      if density:
+          #instead of exact matching density, get density match to the first decimal
+          docs = [doc for doc in docs if round(doc.density, 1) == round(density, 1)]
+      if lattice:
+          docs = [doc for doc in docs if doc.symmetry.crystal_system.value == lattice]
+      return docs
+  
+  def query_material_property(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
+      docs = self.mpr.materials.summary.search(formula=formula, fields=["formula_pretty", desired_prop, "symmetry", "density", "lattice"])
+      docs = self._get_specific_query(docs, space_group_num, density, lattice)
+      if not docs:
+          return []
+      if one_only:
+          docs = [docs[0]]
+      return docs
+  
+  def _get_prop(self, docs, prop):
+      props = []
+      for doc in docs:
+          props.append(getattr(doc, prop))
+      return props
+  
+  def average_neighbors(self, neighbors:dict):
+      total_weight = 0
+      weighted_sum = 0
+      
+      for score, values in neighbors.items():
+          weighted_sum += score * sum(values)
+          total_weight += score * len(values)
+      
+      if total_weight == 0:
+          return 0  
+      else:
+          return weighted_sum / total_weight
+   
+  def k_vals(self, input_param:dict, k:int):
+    num_values = 0
+    for key in input_param:
+        num_values += len(input_param[key])
+    return num_values >= k
+
+  def get_best_matches(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, k=10):
+    """
+    Get the best matches following the scoring rubric.
+    """
+    N_params = {}
+
+    score_criteria = [
+        # Score 3 criteria
+        [
+            {"formula": formula, "lattice": lattice, "space_group_num": space_group_num, "desired_prop": desired_prop},
+            {"formula": formula, "lattice": lattice, "density": density, "desired_prop": desired_prop},
+            {"formula": formula, "space_group_num": space_group_num, "density": density, "desired_prop": desired_prop}
+        ],
+        # Score 2 criteria
+        [
+            {"formula": formula, "lattice": lattice, "desired_prop": desired_prop},
+            {"formula": formula, "space_group_num": space_group_num, "desired_prop": desired_prop},
+            {"formula": formula, "density": density, "desired_prop": desired_prop}
+        ],
+        # Score 1 criteria
+        [{"formula": formula, "desired_prop": desired_prop}]
+    ]
+    
+    for score, criteria in enumerate(score_criteria, start=1):
+        props = []
+        for criterion in criteria:
+            criterion["one_only"] = False  # Apply common property
+            docs = self.query_material_property(**criterion)
+            if docs:
+                props += self._get_prop(docs, desired_prop)
+        N_params[score] = props
+        
+        if self.k_vals(N_params, k):
+            return N_params
+
+    return N_params
+
+  def get_weighted_average_of_neighbors(self, input_params:dict):
+    required_params = ["formula", "desired_prop"]
+    if not all([param in input_params for param in required_params]):
+        raise ValueError(f"Missing required parameters: {required_params}")
+    neighbors = self.get_best_matches(**input_params)
+    return self.average_neighbors(neighbors)

--- a/mapillm/mapi_tools.py
+++ b/mapillm/mapi_tools.py
@@ -260,35 +260,3 @@ for prop in [stability, magnetism, metal, gap_direct, band_gap,
              energy_per_atom, formation_energy_per_atom, volume, density, atomic_density, electronic_energy, ionic_energy, total_energy]:
 # for prop in [band_gap]:
   mapi_tools += prop.get_tools()
-
-
-class ExactMatchingTool():
-  #move to other class when ready
-  def __init__(self):
-    self.mpr = MPRester(os.getenv("MAPI_API_KEY"))
-
-  def _get_specific_query(self, docs, space_group_num=None, density=None, lattice=None):
-      if space_group_num:
-          docs = [doc for doc in docs if doc.symmetry.number == space_group_num]
-      if density:
-          #instead of exact matching density, get density match to the first decimal
-          docs = [doc for doc in docs if round(doc.density, 1) == round(density, 1)]
-      if lattice:
-          docs = [doc for doc in docs if doc.symmetry.crystal_system.value == lattice]
-      return docs
-  
-  def query_material_property(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
-      docs = self.mpr.materials.summary.search(formula=formula, fields=["formula_pretty", desired_prop, "symmetry", "density", "lattice"])
-      docs = self._get_specific_query(docs, space_group_num, density, lattice)
-      if not docs:
-          return []
-      if one_only:
-          docs = [docs[0]]
-      return docs
-  
-  def _get_prop(self, docs, prop):
-      props = []
-      for doc in docs:
-          props.append(getattr(doc, prop))
-      return props
-    

--- a/mapillm/mapi_tools.py
+++ b/mapillm/mapi_tools.py
@@ -260,3 +260,35 @@ for prop in [stability, magnetism, metal, gap_direct, band_gap,
              energy_per_atom, formation_energy_per_atom, volume, density, atomic_density, electronic_energy, ionic_energy, total_energy]:
 # for prop in [band_gap]:
   mapi_tools += prop.get_tools()
+
+
+class ExactMatchingTool():
+  #move to other class when ready
+  def __init__(self):
+    self.mpr = MPRester(os.getenv("MAPI_API_KEY"))
+
+  def _get_specific_query(self, docs, space_group_num=None, density=None, lattice=None):
+      if space_group_num:
+          docs = [doc for doc in docs if doc.symmetry.number == space_group_num]
+      if density:
+          #instead of exact matching density, get density match to the first decimal
+          docs = [doc for doc in docs if round(doc.density, 1) == round(density, 1)]
+      if lattice:
+          docs = [doc for doc in docs if doc.symmetry.crystal_system.value == lattice]
+      return docs
+  
+  def query_material_property(self, formula, desired_prop, space_group_num=None, density=None, lattice=None, one_only=True):
+      docs = self.mpr.materials.summary.search(formula=formula, fields=["formula_pretty", desired_prop, "symmetry", "density", "lattice"])
+      docs = self._get_specific_query(docs, space_group_num, density, lattice)
+      if not docs:
+          return []
+      if one_only:
+          docs = [docs[0]]
+      return docs
+  
+  def _get_prop(self, docs, prop):
+      props = []
+      for doc in docs:
+          props.append(getattr(doc, prop))
+      return props
+    

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email="maykcaldas@gmail.edu",
     url="https://github.com/maykcaldas/MAPI_LLM",
     license="MIT",
-    packages=['mapillm'],
+    packages=find_packages(),
     install_requires=[
         "numpy",
         "pandas",

--- a/tests/test_exact_matching.py
+++ b/tests/test_exact_matching.py
@@ -1,0 +1,33 @@
+from mapillm.mapi_tools import ExactMatchingTool
+
+def test_exact_match():
+    formula="LiCoO2"
+    space_group = 12
+    lattice="Monoclinic"
+    density=4.7
+    prop="band_gap"
+
+    matching_tool = ExactMatchingTool()
+    output = matching_tool.query_material_property(formula, prop, one_only=False)
+    assert len(output) == 9
+
+    matching_tool = ExactMatchingTool()
+    output = matching_tool.query_material_property(formula, prop, one_only=True)
+    assert len(output) == 1
+
+    matching_tool = ExactMatchingTool()
+    specific_output = matching_tool.query_material_property(formula=formula, space_group_num=space_group, density=density, lattice=lattice, desired_prop=prop)
+    assert len(specific_output) == 1
+
+    matching_tool = ExactMatchingTool()
+    specific_output = matching_tool.query_material_property(formula=formula, space_group_num=400, density=density, lattice=lattice, desired_prop=prop)
+    assert len(specific_output) == 0
+
+def test_get_prop():
+    formula="LiCoO2"
+    prop="band_gap"
+
+    matching_tool = ExactMatchingTool()
+    output = matching_tool._get_prop(matching_tool.query_material_property(formula, prop), prop)
+
+    assert type(output) == list and len(output) == 1 and type(output[0]) == float

--- a/tests/test_exact_matching.py
+++ b/tests/test_exact_matching.py
@@ -60,3 +60,4 @@ def test_get_weighted_average_of_neighbors(exact_match):
 
     with pytest.raises(ValueError):
         avg_prop = exact_match.get_weighted_average_of_neighbors(arg_dict)
+

--- a/tests/test_exact_matching.py
+++ b/tests/test_exact_matching.py
@@ -1,33 +1,62 @@
-from mapillm.mapi_tools import ExactMatchingTool
+from mapillm.exact_matching import ExactMatchingTool
+import pytest 
 
-def test_exact_match():
+@pytest.fixture
+def exact_match():
+    return ExactMatchingTool()
+
+
+def test_exact_match(exact_match):
     formula="LiCoO2"
     space_group = 12
     lattice="Monoclinic"
     density=4.7
     prop="band_gap"
 
-    matching_tool = ExactMatchingTool()
-    output = matching_tool.query_material_property(formula, prop, one_only=False)
+    output = exact_match.query_material_property(formula, prop, one_only=False)
     assert len(output) == 9
 
-    matching_tool = ExactMatchingTool()
-    output = matching_tool.query_material_property(formula, prop, one_only=True)
+    output = exact_match.query_material_property(formula, prop, one_only=True)
     assert len(output) == 1
 
-    matching_tool = ExactMatchingTool()
-    specific_output = matching_tool.query_material_property(formula=formula, space_group_num=space_group, density=density, lattice=lattice, desired_prop=prop)
+    specific_output = exact_match.query_material_property(formula=formula, space_group_num=space_group, density=density, lattice=lattice, desired_prop=prop)
     assert len(specific_output) == 1
 
-    matching_tool = ExactMatchingTool()
-    specific_output = matching_tool.query_material_property(formula=formula, space_group_num=400, density=density, lattice=lattice, desired_prop=prop)
+    specific_output = exact_match.query_material_property(formula=formula, space_group_num=400, density=density, lattice=lattice, desired_prop=prop)
     assert len(specific_output) == 0
 
-def test_get_prop():
+def test_get_prop(exact_match):
     formula="LiCoO2"
     prop="band_gap"
 
-    matching_tool = ExactMatchingTool()
-    output = matching_tool._get_prop(matching_tool.query_material_property(formula, prop), prop)
+    output = exact_match._get_prop(exact_match.query_material_property(formula, prop), prop)
 
     assert type(output) == list and len(output) == 1 and type(output[0]) == float
+
+def test_get_best_matches(exact_match):
+    formula="LiFePO4"
+    desired_prop="band_gap"
+    space_group_num=250
+    density=4.87
+    lattice="Cubic"
+
+    neighbors = exact_match.get_best_matches(formula, desired_prop, space_group_num=space_group_num, density=density, lattice=lattice, k=1)
+    assert len(neighbors) >= 1
+
+def test_average_neighbors(exact_match):
+    input_dict = {3: [1,2], 2:[5,1], 1:[0.5]}
+    average_neighbor = round(exact_match.average_neighbors(input_dict), 2)
+    assert average_neighbor == 1.95
+
+def test_get_weighted_average_of_neighbors(exact_match):
+    #should succeed
+    arg_dict = {"formula":"LiFePO4", "desired_prop":"band_gap", "space_group_num":250, "density":4.87, "lattice":"Cubic"}
+
+    avg_prop = exact_match.get_weighted_average_of_neighbors(arg_dict)
+    assert type(avg_prop) == float
+
+    #should fail
+    arg_dict = {"desired_prop":"band_gap", "space_group_num":250, "density":4.87, "lattice":"Cubic"}
+
+    with pytest.raises(ValueError):
+        avg_prop = exact_match.get_weighted_average_of_neighbors(arg_dict)


### PR DESCRIPTION
In this PR:
- Tools can now accept the following parameters:
     - formula (required)
     - lattice 
     - space group number
     - density
     - requested property (required)
- any of the non-required parameters are left out of the query

- Alternative to ICL:
     - Now when a query gives back multiple results, you get a warning & the average of the desired property for all of the results -> this is default behavior, but is an optional flag
     - If a query returns no results, a neighbor search (at least k=10 neighbors) / weighted averaging is done to estimate the property (and user is given a warning). The *weights* for the weighted average are basically 3/4 matching properties=3, 2/4 matching properties=2, etc. 

I added a demo notebook for this as well